### PR TITLE
fix no ano

### DIFF
--- a/_includes/sobre.html
+++ b/_includes/sobre.html
@@ -2,7 +2,7 @@
     <header class="major">
         <h2>Somos PHPDF</h2>
         <p>
-            Desde 2014 atuamos como representantes da tecnologia PHP em Brasília,
+            Desde 2007 atuamos como representantes da tecnologia PHP em Brasília,
             sempre em busca de capacitação e excelência profissional, através de encontros
             organizados mensalmente.
         </p>


### PR DESCRIPTION
O PHPDF é mais velho que a galera nova. 

Antes era PHP-BRASILIA, que na época deu muita confusão e então mudou para PHPDF.